### PR TITLE
Update freesound.py - download sample from combined search results

### DIFF
--- a/freesound.py
+++ b/freesound.py
@@ -305,7 +305,7 @@ class CombinedSearchPager(FreesoundObject):
     available.
     """
     def __getitem__(self, key):
-        return Sound(self.results[key], None)
+        return Sound(self.results[key], self.client)
 
     def more(self):
         """


### PR DESCRIPTION
I receive a results page from combined search.
I then try to download, but get an error:

`'NoneType' object has no attribute 'header'`

The error appears when the FSRequest.retrieve() class method is called. (line 264 at time of writing)

I noticed a difference in the inititiation of Sound under CombinedSearchPager vs Pager, and so my fix is to change line 308:

`return Sound(self.results[key], None)`

to:

`return Sound(self.results[key], self.client)`