### PR TITLE
add get_analysis_frames

### DIFF
--- a/freesound.py
+++ b/freesound.py
@@ -386,12 +386,12 @@ class Sound(FreesoundObject):
 
     def get_analysis_frames(self):
         """
-        Get analysis frames of one descriptor
+        Get analysis frames. Retrieves a list of all computed descriptors for all frames as a FreesoundObject.
+        https://freesound.org/docs/api/analysis_docs.html#analysis-docs
         >>> a = sound.get_analysis_frames()
         """
         uri = self.analysis_frames
-        uri = os.path.splitext(uri)[0]+'.json' #temp bugfix: Freesound API is returning a .yaml in sound.analysis_frames, while it should be .json
-        return FSRequest.request(uri, params, self.client, FreesoundObject)
+        return FSRequest.request(uri, client=self.client, wrapper=FreesoundObject)
 
 
     def get_similar(self, **params):

--- a/freesound.py
+++ b/freesound.py
@@ -370,10 +370,13 @@ class Sound(FreesoundObject):
     def get_analysis(self, descriptors=None, normalized=0):
         """
         Get content-based descriptors.
+        Returns the statistical aggregation as a Sound object. 
         http://freesound.org/docs/api/resources_apiv2.html#sound-analysis
 
-        >>> a = sound.get_analysis(descriptors="lowlevel.pitch.mean")
-        >>> print(a.lowlevel.pitch.mean)
+        Example:
+        >>> analysis_object = sound.get_analysis(descriptors="lowlevel.pitch.mean")
+        >>> mffc_mean = analysis_object.lowlevel.mfcc.mean # <-- access analysis results by using object properties
+        >>> mffc_mean = analysis_object.as_dict()['lowlevel']['mfcc']['mean'] # <-- Is possible to convert it to a Dictionary
         """
         uri = URIS.uri(URIS.SOUND_ANALYSIS, self.id)
         params = {}
@@ -386,9 +389,14 @@ class Sound(FreesoundObject):
 
     def get_analysis_frames(self):
         """
-        Get analysis frames. Retrieves a list of all computed descriptors for all frames as a FreesoundObject.
+        Get analysis frames. 
+        Returns a list of all computed descriptors for all frames as a FreesoundObject.
         https://freesound.org/docs/api/analysis_docs.html#analysis-docs
-        >>> a = sound.get_analysis_frames()
+        
+        Example:
+        >>> analysis_frames_object = sound.get_analysis_frames()
+        >>> pitch_by_frames = analysis_frames_object.lowlevel.pich # <-- access analysis results by using object properties
+        >>> pitch_by_frames = analysis_frames_object.as_dict()['lowlevel']['pich'] # <-- Is possible to convert it to a Dictionary
         """
         uri = self.analysis_frames
         return FSRequest.request(uri, client=self.client, wrapper=FreesoundObject)

--- a/freesound.py
+++ b/freesound.py
@@ -383,6 +383,17 @@ class Sound(FreesoundObject):
             params['normalized'] = normalized
         return FSRequest.request(uri, params, self.client, FreesoundObject)
 
+
+    def get_analysis_frames(self):
+        """
+        Get analysis frames of one descriptor
+        >>> a = sound.get_analysis_frames()
+        """
+        uri = self.analysis_frames
+        uri = os.path.splitext(uri)[0]+'.json' #temp bugfix: Freesound API is returning a .yaml in sound.analysis_frames, while it should be .json
+        return FSRequest.request(uri, params, self.client, FreesoundObject)
+
+
     def get_similar(self, **params):
         """
         Get similar sounds based on content-based descriptors.


### PR DESCRIPTION
### Add get_analysis_frames:

Getting the features by frame was not offered by freesound-python (only the statistical stats). 
I am adding this method, I tried it locally and so far works fine.

I wanted to offer a similar interface as `get_analysis(self, descriptors=None, normalized=0)`, but
the response I get seems to ignore the provided parameters. Maybe this is the expected behaviour, so I am only providing a simpler `get_analysis_frames` that fetches all features. 
 **However**, I believe that it would be nicer to be able to provide the `descriptors` in the request and save some bandwidth.

This is what I had in mind:
```python
    def get_analysis_frames(self):
        """
        Get analysis frames of one descriptor
        >>> a = sound.get_analysis_frames()
        """
        uri = self.analysis_frames
        uri = os.path.splitext(uri)[0]+'.json' #temp bugfix: Freesound API is returning a .yaml in sound.analysis_frames, while it should be .json
        params = {}
        if descriptors:
            params['descriptors'] = descriptors ## <--- WILL IGNORE IT
        if normalized: 
            params['normalized'] = normalized
        return FSRequest.request(uri, params, self.client, FreesoundObject)
```


==========================
#### Sound.analysis_frames is not correct
**Also**,  the `Sound.analysis_frames` object received from `freesound_client.get_sound()` is pointing to a `.yaml` instead of the correct `.json`
I opened an issue for it: https://github.com/MTG/freesound-python/issues/23
I am making a temporal fix on my PR, but when this issue is fixed it could be removed
