### PR TITLE
Move to requests and drop Python 2 support

### DIFF
--- a/.github/workflows/python-smoke-test.yml
+++ b/.github/workflows/python-smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/python-smoke-test.yml
+++ b/.github/workflows/python-smoke-test.yml
@@ -1,0 +1,31 @@
+name: Run examples
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Run smoke test
+      env:
+        FREESOUND_API_KEY: ${{ secrets.FREESOUND_API_KEY }}
+      run: |
+        python examples.py

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,6 @@ freesound.py
 ============
 
 A Python client for the [Freesound](https://freesound.org) APIv2.
-This client should both in Python 2 and 3.
 
 Find the API documentation at http://www.freesound.org/docs/api/. 
 Apply for an API key at https://www.freesound.org/apiv2/apply/. 
@@ -29,8 +28,7 @@ for sound in results:
 
 ```
 
-Installation
-============
+## Installation
 1) clone or download
 
 2) run:
@@ -38,7 +36,60 @@ Installation
 python setup.py install
 ```
 
-Alternatively you should also be able to install directly from Github with:
+Alternatively you should also be able to install directly from GitHub with:
 ```
 pip install git+https://github.com/MTG/freesound-python
+```
+
+## Advanced usage
+
+### Modifying the requests' session:
+
+You can easily extend/modify the way how requests are done by interacting directly with
+the session object of the client.
+
+For example, adding proxies:
+```python
+proxies = {
+  'http': 'http://10.10.1.10:3128',
+  'https': 'http://10.10.1.10:1080',
+}
+client.session.proxies.update(proxies)
+```
+
+or adding [rate limiting](https://github.com/JWCook/requests-ratelimiter):
+```python
+from requests_ratelimiter import LimiterSession
+
+# Apply a rate-limit (59 requests per minute) to all requests
+client.session = LimiterSession(per_minute=59)
+```
+
+### Authenticating with OAuth
+Here is an example authentication flow with the help of [Requests-OAuthlib](https://requests-oauthlib.readthedocs.io/).
+```python
+from requests_oauthlib import OAuth2Session
+
+import freesound
+
+client_id = "<your_client_id>"
+client_secret = "<your_client_secret>"
+
+# do the OAuth dance
+oauth = OAuth2Session(client_id)
+
+authorization_url, state = oauth.authorization_url(
+    "https://freesound.org/apiv2/oauth2/authorize/"
+)
+print(f"Please go to {authorization_url} and authorize access.")
+
+authorization_code = input("Please enter the authorization code:")
+oauth_token = oauth.fetch_token(
+    "https://freesound.org/apiv2/oauth2/access_token/",
+    authorization_code,
+    client_secret=client_secret,
+)
+
+client = freesound.FreesoundClient()
+client.set_token(oauth_token["access_token"], "oauth")
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 freesound.py
 ============
 
-A Python client for the [Freesound](http://freesound.org) APIv2.
+A Python client for the [Freesound](https://freesound.org) APIv2.
 This client should both in Python 2 and 3.
 
 Find the API documentation at http://www.freesound.org/docs/api/. 
@@ -11,7 +11,7 @@ The client automatically maps function arguments to http parameters of the API.
 JSON results are converted to python objects, but are also available in their original form (JSON loaded into dictionaries) using the method `.as_dict()` of returned objets (see [examples file](https://github.com/MTG/freesound-python/blob/master/examples.py)). 
 The main object types (`Sound`, `User`, `Pack`) are augmented with the corresponding API calls.
 
-Note that POST resources are not supported. Downloading full quality sounds requires Oauth2 authentication (see http://freesound.org/docs/api/authentication.html). Oauth2 authentication is supported by passing an access token, but you are expected to implement the workflow to obtain that access token. Here is an [example implementation of the Freesound OAuth2 workflow using Flask](https://gist.github.com/ffont/3607ba4af9814f3877cd42894a564222).
+Note that POST resources are not supported. Downloading full quality sounds requires Oauth2 authentication (see https://freesound.org/docs/api/authentication.html). Oauth2 authentication is supported by passing an access token, but you are expected to implement the workflow to obtain that access token. Here is an [example implementation of the Freesound OAuth2 workflow using Flask](https://gist.github.com/ffont/3607ba4af9814f3877cd42894a564222).
 
 Example usage:
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -44,7 +44,7 @@
 <p>Find the API documentation at <a class="reference external" href="http://www.freesound.org/docs/api/">http://www.freesound.org/docs/api/</a>.</p>
 <p>Apply for an API key at <a class="reference external" href="http://www.freesound.org/api/apply/">http://www.freesound.org/api/apply/</a>.</p>
 <p>The client automatically maps function arguments to http parameters of the API. JSON results are converted to python objects. The main object types (Sound, User, Pack) are augmented with the corresponding API calls.</p>
-<p>Note that POST resources are not supported. Downloading full quality sounds requires Oauth2 authentication (see <a class="reference external" href="http://freesound.org/docs/api/authentication.html">http://freesound.org/docs/api/authentication.html</a>). Oauth2 authentication is supported, but you are expected to implement the workflow.</p>
+<p>Note that POST resources are not supported. Downloading full quality sounds requires Oauth2 authentication (see <a class="reference external" href="https://freesound.org/docs/api/authentication.html">https://freesound.org/docs/api/authentication.html</a>). Oauth2 authentication is supported, but you are expected to implement the workflow.</p>
 <dl class="class">
 <dt id="freesound.CombinedSearchPager">
 <em class="property">class </em><tt class="descclassname">freesound.</tt><tt class="descname">CombinedSearchPager</tt><big>(</big><em>json_dict</em>, <em>client</em><big>)</big><a class="reference internal" href="_modules/freesound.html#CombinedSearchPager"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.CombinedSearchPager" title="Permalink to this definition">¶</a></dt>
@@ -79,7 +79,7 @@ Use <a class="reference internal" href="#freesound.CombinedSearchPager.more" tit
 <dt id="freesound.FreesoundClient.combined_search">
 <tt class="descname">combined_search</tt><big>(</big><em>**params</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.combined_search"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.combined_search" title="Permalink to this definition">¶</a></dt>
 <dd><p>Combine both text and content-based queries.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#combined-search">http://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#combined-search">https://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sounds</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">combined_search</span><span class="p">(</span><span class="n">target</span><span class="o">=</span><span class="s">&quot;lowlevel.pitch.mean:220&quot;</span><span class="p">,</span> <span class="nb">filter</span><span class="o">=</span><span class="s">&quot;single-note&quot;</span><span class="p">)</span>  
 </pre></div>
 </div>
@@ -90,7 +90,7 @@ Use <a class="reference internal" href="#freesound.CombinedSearchPager.more" tit
 <tt class="descname">content_based_search</tt><big>(</big><em>**params</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.content_based_search"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.content_based_search" title="Permalink to this definition">¶</a></dt>
 <dd><p>Search sounds using a content-based descriptor target and/or filter
 See essentia_example.py for an example using essentia
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#content-search">http://freesound.org/docs/api/resources_apiv2.html#content-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#content-search">https://freesound.org/docs/api/resources_apiv2.html#content-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sounds</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">content_based_search</span><span class="p">(</span><span class="n">target</span><span class="o">=</span><span class="s">&quot;lowlevel.pitch.mean:220&quot;</span><span class="p">,</span><span class="n">descriptors_filter</span><span class="o">=</span><span class="s">&quot;lowlevel.pitch_instantaneous_confidence.mean:[0.8 TO 1]&quot;</span><span class="p">,</span><span class="n">fields</span><span class="o">=</span><span class="s">&quot;id,name,url&quot;</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="k">for</span> <span class="n">snd</span> <span class="ow">in</span> <span class="n">sounds</span><span class="p">:</span> <span class="k">print</span> <span class="n">snd</span><span class="o">.</span><span class="n">name</span> 
 </pre></div>
@@ -101,7 +101,7 @@ See essentia_example.py for an example using essentia
 <dt id="freesound.FreesoundClient.get_pack">
 <tt class="descname">get_pack</tt><big>(</big><em>pack_id</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.get_pack"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.get_pack" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get a user object by username
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#combined-search">http://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#combined-search">https://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">p</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">get_pack</span><span class="p">(</span><span class="mi">3416</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -111,7 +111,7 @@ See essentia_example.py for an example using essentia
 <dt id="freesound.FreesoundClient.get_sound">
 <tt class="descname">get_sound</tt><big>(</big><em>sound_id</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.get_sound"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.get_sound" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get a sound object by id
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#sound-resources">http://freesound.org/docs/api/resources_apiv2.html#sound-resources</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#sound-resources">https://freesound.org/docs/api/resources_apiv2.html#sound-resources</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sound</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">get_sound</span><span class="p">(</span><span class="mi">6</span><span class="p">)</span> 
 </pre></div>
 </div>
@@ -121,7 +121,7 @@ See essentia_example.py for an example using essentia
 <dt id="freesound.FreesoundClient.get_user">
 <tt class="descname">get_user</tt><big>(</big><em>username</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.get_user"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.get_user" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get a user object by username
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#combined-search">http://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#combined-search">https://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">u</span><span class="o">=</span><span class="n">c</span><span class="o">.</span><span class="n">get_user</span><span class="p">(</span><span class="s">&quot;xserra&quot;</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -131,8 +131,8 @@ See essentia_example.py for an example using essentia
 <dt id="freesound.FreesoundClient.set_token">
 <tt class="descname">set_token</tt><big>(</big><em>token</em>, <em>auth_type='token'</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.set_token"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.set_token" title="Permalink to this definition">¶</a></dt>
 <dd><p>Set your API key or Oauth2 token
-<a class="reference external" href="http://freesound.org/docs/api/authentication.html">http://freesound.org/docs/api/authentication.html</a>
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#combined-search">http://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/authentication.html">https://freesound.org/docs/api/authentication.html</a>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#combined-search">https://freesound.org/docs/api/resources_apiv2.html#combined-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">c</span><span class="o">.</span><span class="n">set_token</span><span class="p">(</span><span class="s">&quot;&lt;your_api_key&gt;&quot;</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -143,7 +143,7 @@ See essentia_example.py for an example using essentia
 <tt class="descname">text_search</tt><big>(</big><em>**params</em><big>)</big><a class="reference internal" href="_modules/freesound.html#FreesoundClient.text_search"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.FreesoundClient.text_search" title="Permalink to this definition">¶</a></dt>
 <dd><p>Search sounds using a text query and/or filter. Returns an iterable Pager object.
 The fields parameter allows you to specify the information you want in the results list
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#text-search">http://freesound.org/docs/api/resources_apiv2.html#text-search</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#text-search">https://freesound.org/docs/api/resources_apiv2.html#text-search</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sounds</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">text_search</span><span class="p">(</span><span class="n">query</span><span class="o">=</span><span class="s">&quot;dubstep&quot;</span><span class="p">,</span> <span class="nb">filter</span><span class="o">=</span><span class="s">&quot;tag:loop&quot;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="s">&quot;id,name,url&quot;</span><span class="p">)</span> 
 <span class="gp">&gt;&gt;&gt; </span><span class="k">for</span> <span class="n">snd</span> <span class="ow">in</span> <span class="n">sounds</span><span class="p">:</span> <span class="k">print</span> <span class="n">snd</span><span class="o">.</span><span class="n">name</span> 
 </pre></div>
@@ -181,7 +181,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.Pack.get_sounds">
 <tt class="descname">get_sounds</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#Pack.get_sounds"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.Pack.get_sounds" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get pack sounds
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#pack-sounds">http://freesound.org/docs/api/resources_apiv2.html#pack-sounds</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#pack-sounds">https://freesound.org/docs/api/resources_apiv2.html#pack-sounds</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sounds</span> <span class="o">=</span> <span class="n">p</span><span class="o">.</span><span class="n">get_sounds</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -224,7 +224,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.Sound.get_analysis">
 <tt class="descname">get_analysis</tt><big>(</big><em>descriptors=None</em><big>)</big><a class="reference internal" href="_modules/freesound.html#Sound.get_analysis"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.Sound.get_analysis" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get content-based descriptors.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#sound-analysis">http://freesound.org/docs/api/resources_apiv2.html#sound-analysis</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#sound-analysis">https://freesound.org/docs/api/resources_apiv2.html#sound-analysis</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">a</span> <span class="o">=</span> <span class="n">sound</span><span class="o">.</span><span class="n">get_analysis</span><span class="p">(</span><span class="n">descriptors</span><span class="o">=</span><span class="s">&quot;lowlevel.pitch.mean&quot;</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="k">print</span><span class="p">(</span><span class="n">a</span><span class="o">.</span><span class="n">lowlevel</span><span class="o">.</span><span class="n">pitch</span><span class="o">.</span><span class="n">mean</span><span class="p">)</span>
 </pre></div>
@@ -235,7 +235,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.Sound.get_comments">
 <tt class="descname">get_comments</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#Sound.get_comments"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.Sound.get_comments" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get user comments.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#sound-comments">http://freesound.org/docs/api/resources_apiv2.html#sound-comments</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#sound-comments">https://freesound.org/docs/api/resources_apiv2.html#sound-comments</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">comments</span> <span class="o">=</span> <span class="n">sound</span><span class="o">.</span><span class="n">get_comments</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -245,7 +245,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.Sound.get_similar">
 <tt class="descname">get_similar</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#Sound.get_similar"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.Sound.get_similar" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get similar sounds based on content-based descriptors.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#similar-sounds">http://freesound.org/docs/api/resources_apiv2.html#similar-sounds</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#similar-sounds">https://freesound.org/docs/api/resources_apiv2.html#similar-sounds</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span> <span class="o">=</span> <span class="n">sound</span><span class="o">.</span><span class="n">get_similar</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -255,7 +255,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.Sound.retrieve">
 <tt class="descname">retrieve</tt><big>(</big><em>directory</em>, <em>name=False</em><big>)</big><a class="reference internal" href="_modules/freesound.html#Sound.retrieve"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.Sound.retrieve" title="Permalink to this definition">¶</a></dt>
 <dd><p>Download the original sound file (requires Oauth2 authentication).
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required">http://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required">https://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">sound</span><span class="o">.</span><span class="n">retrieve</span><span class="p">(</span><span class="s">&quot;/tmp&quot;</span><span class="p">)</span> 
 </pre></div>
 </div>
@@ -283,7 +283,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.User.get_bookmark_categories">
 <tt class="descname">get_bookmark_categories</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#User.get_bookmark_categories"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.User.get_bookmark_categories" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get user bookmark categories.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories">http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories">https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">u</span><span class="o">.</span><span class="n">get_bookmark_categories</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -293,7 +293,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.User.get_bookmark_category_sounds">
 <tt class="descname">get_bookmark_category_sounds</tt><big>(</big><em>category_id</em><big>)</big><a class="reference internal" href="_modules/freesound.html#User.get_bookmark_category_sounds"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.User.get_bookmark_category_sounds" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get user bookmarks.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds">http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds">https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">p</span><span class="o">=</span><span class="n">u</span><span class="o">.</span><span class="n">get_bookmark_category_sounds</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -303,7 +303,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.User.get_packs">
 <tt class="descname">get_packs</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#User.get_packs"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.User.get_packs" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get user packs.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#user-packs">http://freesound.org/docs/api/resources_apiv2.html#user-packs</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#user-packs">https://freesound.org/docs/api/resources_apiv2.html#user-packs</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">u</span><span class="o">.</span><span class="n">get_packs</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -313,7 +313,7 @@ The fields parameter allows you to specify the information you want in the resul
 <dt id="freesound.User.get_sounds">
 <tt class="descname">get_sounds</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/freesound.html#User.get_sounds"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#freesound.User.get_sounds" title="Permalink to this definition">¶</a></dt>
 <dd><p>Get user sounds.
-<a class="reference external" href="http://freesound.org/docs/api/resources_apiv2.html#user-sounds">http://freesound.org/docs/api/resources_apiv2.html#user-sounds</a></p>
+<a class="reference external" href="https://freesound.org/docs/api/resources_apiv2.html#user-sounds">https://freesound.org/docs/api/resources_apiv2.html#user-sounds</a></p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">u</span><span class="o">.</span><span class="n">get_sounds</span><span class="p">()</span>
 </pre></div>
 </div>

--- a/download_bookmarks_example.py
+++ b/download_bookmarks_example.py
@@ -3,9 +3,10 @@
 # https://freesound.org/docs/api/authentication.html#oauth2-authentication
 # Make sure you use the actual oauth token and not the authorisation token in
 # step 2
-import freesound
 import os
 import sys
+
+import freesound
 
 access_token = os.getenv('FREESOUND_ACCESS_TOKEN', None)
 if access_token is None:
@@ -46,7 +47,7 @@ for bookmark in bookmarks_results_pager:
             if sound.name.endswith(sound.type):
                 filename = sound.name
             else:
-                filename = "{}.{}".format(sound.name, sound.type)
+                filename = f"{sound.name}.{sound.type}"
 
             sound.retrieve(path_name, name=filename)
 

--- a/download_bookmarks_example.py
+++ b/download_bookmarks_example.py
@@ -3,7 +3,6 @@
 # https://freesound.org/docs/api/authentication.html#oauth2-authentication
 # Make sure you use the actual oauth token and not the authorisation token in
 # step 2
-from __future__ import print_function
 import freesound
 import os
 import sys
@@ -47,7 +46,7 @@ for bookmark in bookmarks_results_pager:
             if sound.name.endswith(sound.type):
                 filename = sound.name
             else:
-                filename = "%s.%s" % (sound.name, sound.type)
+                filename = "{}.{}".format(sound.name, sound.type)
 
             sound.retrieve(path_name, name=filename)
 

--- a/download_bookmarks_example.py
+++ b/download_bookmarks_example.py
@@ -9,7 +9,7 @@ import sys
 
 access_token = os.getenv('FREESOUND_ACCESS_TOKEN', None)
 if access_token is None:
-    print("You need to set your ACCESS TOKEN as an evironment variable",)
+    print("You need to set your ACCESS TOKEN as an environment variable")
     print("named FREESOUND_ACCESS_TOKEN")
     sys.exit(-1)
 

--- a/essentia_example.py
+++ b/essentia_example.py
@@ -56,7 +56,7 @@ def query_by_voice():
     c = freesound.FreesoundClient()
     c.set_token("<YOUR_API_KEY_HERE>","token")
     d = record_audio()
-    mfcc_frames = extract_mfcc(d);
+    mfcc_frames = extract_mfcc(d)
     mfcc_mean=numpy.mean(mfcc_frames,1)    
     mfcc_var=numpy.var(mfcc_frames,1)   
     m =",".join(["%.3f"%x for x in mfcc_mean])
@@ -73,6 +73,3 @@ def query_by_voice():
         
     
     return results
-    
-    
-    

--- a/examples.py
+++ b/examples.py
@@ -4,7 +4,7 @@ import sys
 
 api_key = os.getenv('FREESOUND_API_KEY', None)
 if api_key is None:
-    print("You need to set your API key as an evironment variable",)
+    print("You need to set your API key as an environment variable")
     print("named FREESOUND_API_KEY")
     sys.exit(-1)
 
@@ -44,7 +44,7 @@ analysis = sound.get_analysis()
 
 mfcc = analysis.lowlevel.mfcc.mean
 print("Mfccs:", mfcc)
-# you can also get the original json (this apply to any FreesoundObject):
+# you can also get the original json (this applies to any FreesoundObject):
 print(analysis.as_dict())
 print()
 

--- a/examples.py
+++ b/examples.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import freesound
 import os
 import sys

--- a/examples.py
+++ b/examples.py
@@ -1,6 +1,7 @@
-import freesound
 import os
 import sys
+
+import freesound
 
 api_key = os.getenv('FREESOUND_API_KEY', None)
 if api_key is None:

--- a/freesound.py
+++ b/freesound.py
@@ -79,7 +79,7 @@ class FreesoundClient:
     >>> c = FreesoundClient()
     >>> c.set_token("<your_api_key>")
     """
-    
+
     def __init__(self):
         self.auth = None  # should be set later
         self.session = Session()
@@ -346,13 +346,13 @@ class Sound(FreesoundObject):
             path = Path(directory,
                         name if name else self.previews.preview_lq_mp3.split("/")[-1],
                         )
-        except AttributeError:
+        except AttributeError as exc:
             raise FreesoundException(
                 '-',
                 'Preview uris are not present in your sound object. Please add'
                 ' them using the fields parameter in your request. See '
                 ' https://www.freesound.org/docs/api/resources_apiv2.html#response-sound-list.'  # noqa
-            )
+            ) from exc
         return FSRequest.retrieve(
             self.previews.preview_lq_mp3,
             self.client,
@@ -362,7 +362,7 @@ class Sound(FreesoundObject):
     def get_analysis(self, descriptors=None, normalized=0):
         """
         Get content-based descriptors.
-        Returns the statistical aggregation as a Sound object. 
+        Returns the statistical aggregation as a Sound object.
         https://freesound.org/docs/api/resources_apiv2.html#sound-analysis
 
         Example:
@@ -380,10 +380,10 @@ class Sound(FreesoundObject):
 
     def get_analysis_frames(self):
         """
-        Get analysis frames. 
+        Get analysis frames.
         Returns a list of all computed descriptors for all frames as a FreesoundObject.
         https://freesound.org/docs/api/analysis_docs.html#analysis-docs
-        
+
         Example:
         >>> analysis_frames_object = sound.get_analysis_frames()
         >>> pitch_by_frames = analysis_frames_object.lowlevel.pich # <-- access analysis results by using object properties

--- a/freesound.py
+++ b/freesound.py
@@ -1,9 +1,9 @@
 """
 A python client for the Freesound API.
 
-Find the API documentation at http://www.freesound.org/docs/api/.
+Find the API documentation at https://www.freesound.org/docs/api/.
 
-Apply for an API key at http://www.freesound.org/api/apply/.
+Apply for an API key at https://www.freesound.org/api/apply/.
 
 The client automatically maps function arguments to http parameters of the API.
 JSON results are converted to python objects. The main object types (Sound,
@@ -11,7 +11,7 @@ User, Pack) are augmented with the corresponding API calls.
 
 Note that POST resources are not supported. Downloading full quality sounds
 requires Oauth2 authentication
-(see http://freesound.org/docs/api/authentication.html). Oauth2 authentication
+(see https://freesound.org/docs/api/authentication.html). Oauth2 authentication
 is supported, but you are expected to implement the workflow.
 """
 import re
@@ -88,7 +88,7 @@ class FreesoundClient:
         """
         Get a sound object by id
         Relevant params: descriptors, fields, normalized
-        http://freesound.org/docs/api/resources_apiv2.html#sound-resources
+        https://freesound.org/docs/api/resources_apiv2.html#sound-resources
 
         >>> sound = c.get_sound(6)
         """
@@ -100,7 +100,7 @@ class FreesoundClient:
         Search sounds using a text query and/or filter. Returns an iterable
         Pager object. The fields parameter allows you to specify the
         information you want in the results list
-        http://freesound.org/docs/api/resources_apiv2.html#text-search
+        https://freesound.org/docs/api/resources_apiv2.html#text-search
 
         >>> sounds = c.text_search(
         >>>     query="dubstep", filter="tag:loop", fields="id,name,url"
@@ -122,7 +122,7 @@ class FreesoundClient:
         """
         Search sounds using a content-based descriptor target and/or filter
         See essentia_example.py for an example using essentia
-        http://freesound.org/docs/api/resources_apiv2.html#content-search
+        https://freesound.org/docs/api/resources_apiv2.html#content-search
 
         >>> sounds = c.content_based_search(
         >>>     target="lowlevel.pitch.mean:220",
@@ -140,7 +140,7 @@ class FreesoundClient:
     def combined_search(self, **params):
         """
         Combine both text and content-based queries.
-        http://freesound.org/docs/api/resources_apiv2.html#combined-search
+        https://freesound.org/docs/api/resources_apiv2.html#combined-search
 
         >>> sounds = c.combined_search(
         >>>     target="lowlevel.pitch.mean:220",
@@ -157,7 +157,7 @@ class FreesoundClient:
     def get_user(self, username):
         """
         Get a user object by username
-        http://freesound.org/docs/api/resources_apiv2.html#combined-search
+        https://freesound.org/docs/api/resources_apiv2.html#combined-search
 
         >>> u = c.get_user("xserra")
         """
@@ -167,7 +167,7 @@ class FreesoundClient:
     def get_pack(self, pack_id):
         """
         Get a user object by username
-        http://freesound.org/docs/api/resources_apiv2.html#combined-search
+        https://freesound.org/docs/api/resources_apiv2.html#combined-search
 
         >>> p = c.get_pack(3416)
         """
@@ -177,8 +177,8 @@ class FreesoundClient:
     def set_token(self, token, auth_type="token"):
         """
         Set your API key or Oauth2 token
-        http://freesound.org/docs/api/authentication.html
-        http://freesound.org/docs/api/resources_apiv2.html#combined-search
+        https://freesound.org/docs/api/authentication.html
+        https://freesound.org/docs/api/resources_apiv2.html#combined-search
 
         >>> c.set_token("<your_api_key>")
         """
@@ -327,7 +327,7 @@ class Sound(FreesoundObject):
     def retrieve(self, directory, name=False):
         """
         Download the original sound file (requires Oauth2 authentication).
-        http://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required
+        https://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required
 
          >>> sound.retrieve("/tmp")
         """
@@ -351,7 +351,7 @@ class Sound(FreesoundObject):
                 '-',
                 'Preview uris are not present in your sound object. Please add'
                 ' them using the fields parameter in your request. See '
-                ' http://www.freesound.org/docs/api/resources_apiv2.html#response-sound-list.'  # noqa
+                ' https://www.freesound.org/docs/api/resources_apiv2.html#response-sound-list.'  # noqa
             )
         return FSRequest.retrieve(
             self.previews.preview_lq_mp3,
@@ -363,7 +363,7 @@ class Sound(FreesoundObject):
         """
         Get content-based descriptors.
         Returns the statistical aggregation as a Sound object. 
-        http://freesound.org/docs/api/resources_apiv2.html#sound-analysis
+        https://freesound.org/docs/api/resources_apiv2.html#sound-analysis
 
         Example:
         >>> analysis_object = sound.get_analysis(descriptors="lowlevel.pitch.mean")
@@ -397,7 +397,7 @@ class Sound(FreesoundObject):
         Get similar sounds based on content-based descriptors.
         Relevant params: page, page_size, fields, descriptors, normalized,
         descriptors_filter
-        http://freesound.org/docs/api/resources_apiv2.html#similar-sounds
+        https://freesound.org/docs/api/resources_apiv2.html#similar-sounds
 
         >>> s = sound.get_similar()
         """
@@ -408,7 +408,7 @@ class Sound(FreesoundObject):
         """
         Get user comments.
         Relevant params: page, page_size
-        http://freesound.org/docs/api/resources_apiv2.html#sound-comments
+        https://freesound.org/docs/api/resources_apiv2.html#sound-comments
 
         >>> comments = sound.get_comments()
         """
@@ -430,7 +430,7 @@ class User(FreesoundObject):
         """
         Get user sounds.
         Relevant params: page, page_size, fields, descriptors, normalized
-        http://freesound.org/docs/api/resources_apiv2.html#user-sounds
+        https://freesound.org/docs/api/resources_apiv2.html#user-sounds
 
         >>> u.get_sounds()
         """
@@ -441,7 +441,7 @@ class User(FreesoundObject):
         """
         Get user packs.
         Relevant params: page, page_size
-        http://freesound.org/docs/api/resources_apiv2.html#user-packs
+        https://freesound.org/docs/api/resources_apiv2.html#user-packs
 
         >>> u.get_packs()
         """
@@ -452,7 +452,7 @@ class User(FreesoundObject):
         """
         Get user bookmark categories.
         Relevant params: page, page_size
-        http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories
+        https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-categories
 
         >>> u.get_bookmark_categories()
         """
@@ -463,7 +463,7 @@ class User(FreesoundObject):
         """
         Get user bookmarks.
         Relevant params: page, page_size, fields, descriptors, normalized
-        http://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds
+        https://freesound.org/docs/api/resources_apiv2.html#user-bookmark-category-sounds
 
         >>> p = u.get_bookmark_category_sounds(0)
         """
@@ -487,7 +487,7 @@ class Pack(FreesoundObject):
         """
         Get pack sounds
         Relevant params: page, page_size, fields, descriptors, normalized
-        http://freesound.org/docs/api/resources_apiv2.html#pack-sounds
+        https://freesound.org/docs/api/resources_apiv2.html#pack-sounds
 
         >>> sounds = p.get_sounds()
         """

--- a/freesound.py
+++ b/freesound.py
@@ -258,6 +258,12 @@ class FSRequest:
 
     @staticmethod
     def retrieve(url, client, path, reporthook=None):
+        """
+        :param reporthook: a callback which is called when a block of data
+        has been downloaded. The callback should have a signature such as
+        def updateProgress(self, count, blockSize, totalSize)
+        For further reference, check the urllib docs.
+        """
         resp = client.session.get(url, auth=client.auth)
         try:
             resp.raise_for_status()
@@ -338,6 +344,11 @@ class Sound(FreesoundObject):
         https://freesound.org/docs/api/resources_apiv2.html#download-sound-oauth2-required
 
          >>> sound.retrieve("/tmp")
+
+        :param reporthook: a callback which is called when a block of data
+        has been downloaded. The callback should have a signature such as
+        def updateProgress(self, count, blockSize, totalSize)
+        For further reference, check the urllib docs.
         """
         filename = (name if name else self.name).replace('/', '_')
         path = Path(directory, filename)

--- a/freesound.py
+++ b/freesound.py
@@ -289,7 +289,7 @@ class Pager(FreesoundObject):
 
 class GenericPager(Pager):
     """
-    Paginates results for objects different than Sound.
+    Paginates results for objects different from Sound.
     """
 
     def __getitem__(self, key):

--- a/freesound.py
+++ b/freesound.py
@@ -390,7 +390,7 @@ class Sound(FreesoundObject):
         >>> pitch_by_frames = analysis_frames_object.as_dict()['lowlevel']['pich'] # <-- Is possible to convert it to a Dictionary
         """
         uri = self.analysis_frames
-        return FSRequest.request(uri, client=self.client, wrapper=FreesoundObject)
+        return FSRequest.request(uri, params=None, client=self.client, wrapper=FreesoundObject)
 
     def get_similar(self, **params):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from distutils.core import setup
 
-setup(name='freesound-python',
-      version='2.0',
-      py_modules=['freesound'],
-      install_requires=['requests<3.0,>2.27'],
-      python_requires='>=3.6'
-      )
+setup(
+    name="freesound-python",
+    version="1.1",
+    py_modules=["freesound"],
+    install_requires=["requests<3.0,>2.27"],
+    python_requires=">=3.6",
+)

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from distutils.core import setup
 setup(name='freesound-python',
       version='2.0',
       py_modules=['freesound'],
-      install_requires=['requests<3.0,>2.0'],
+      install_requires=['requests<3.0,>2.27'],
       python_requires='>=3.6'
       )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from distutils.core import setup
+
 setup(name='freesound-python',
-      version='1.0',
+      version='2.0',
       py_modules=['freesound'],
+      install_requires=['requests<3.0,>2.0'],
+      python_requires='>=3.6'
       )


### PR DESCRIPTION
This PR updates the client and brings in [requests](https://requests.readthedocs.io/en/latest/) for extra ease of use.
My main motivation to use requests was to get connection pooling when doing multiple requests to the API.
The only breaking change in the API of the client should be that the `retrieve` functions no longer accept a `reporthook` parameter.

With requests users can now easily extend/modify the way how requests are done by interacting directly with the session object of the client.
For example, adding proxies:
```python
proxies = {
  'http': 'http://10.10.1.10:3128',
  'https': 'http://10.10.1.10:1080',
}
client.session.proxies.update(proxies)
```

or adding [rate limiting](https://github.com/JWCook/requests-ratelimiter):
```python
from requests_ratelimiter import LimiterSession

# Apply a rate-limit (59 requests per minute) to all requests
client.session = LimiterSession(per_minute=59)
```